### PR TITLE
Enable Modbus logging via main stream

### DIFF
--- a/main/grbl/config.h
+++ b/main/grbl/config.h
@@ -206,6 +206,7 @@ or EMI triggering the related interrupt falsely or too many times.
 // Enables code for debugging purposes. Not for general use and always in constant flux.
 #define DEBUG // Uncomment to enable. Default disabled.
 //#define DEBUGOUT 0 // Uncomment to claim serial port with given instance number and add HAL entry point for debug output.
+#define MODBUS_DEBUG 1
 
 /*! @name Status report frequency
 Some status report data isn't necessary for realtime, only intermittently, because the values don't


### PR DESCRIPTION
## Summary
- log Modbus traffic without requiring DEBUGOUT
- add `<stdio.h>` include for snprintf

## Testing
- `pio run --silent`


------
https://chatgpt.com/codex/tasks/task_b_68429c30ead88323bc4fc71f5513ec8d